### PR TITLE
Security Fix for Prototype Pollution - huntr.dev

### DIFF
--- a/src/methods/set.ts
+++ b/src/methods/set.ts
@@ -1,5 +1,12 @@
 import { THE_PARAMETER_IS_ILLEGAL, setValue, combingPathKey, isComplexPath, showError, toString } from '../util'
 
+/**
+ * Returns true, if given key is included in the blacklisted
+ * keys.
+ * @param key key for check, string.
+ */
+const isPrototypePolluted = (key: string): Boolean => ['__proto__', 'prototype', 'constructor'].includes(key)
+
 export default (data: any, path: string | number, value: any): void => {
   path = toString(path)
   if (!(data && path)) return showError(THE_PARAMETER_IS_ILLEGAL)
@@ -9,6 +16,8 @@ export default (data: any, path: string | number, value: any): void => {
 
   for (let i = 0, len = keys.length; i < len; i++) {
     let key = keys[i]
+
+    if (isPrototypePolluted(key)) continue
 
     if (data[key] == null) {
       data[key] = {}

--- a/test/spec/set_spec.js
+++ b/test/spec/set_spec.js
@@ -128,4 +128,10 @@ describe('jsonuri.set', () => {
     jsonuri.set(o, 5, 1)
     expect(o).toEqual([undefined, undefined, undefined, undefined, undefined, 1])
   })
+  // ==========
+  it('check prototype pollution', () => {
+    jsonuri.set(obj, '__proto__/polluted', 'Yes! Its Polluted')
+    expect(obj.polluted).toEqual('Yes! Its Polluted')
+    expect({}.polluted).toEqual(undefined)
+  })
 })


### PR DESCRIPTION
https://huntr.dev/users/d3v53c has fixed the Prototype Pollution vulnerability 🔨. Think you could fix a vulnerability like this?

Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/jsonuri/pull/1
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/jsonuri/1/README.md

### User Comments:

### 📊 Metadata *

jsonuri is vulnerable to Prototype Pollution.


#### Bounty URL: https://www.huntr.dev/bounties/1-npm-jsonuri

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. The bug is fixed by validating the input strArray to check for prototypes. It is implemented by a simple validation to check for prototype keywords (proto, constructor and prototype), where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *

Create the following PoC file:

```
// poc.js
const {set} = require('jsonuri')
var obj = {}
console.log("Before : " + {}.polluted);
set({}, ['__proto__/polluted'], 'Yes! Its Polluted');
console.log("After : " + {}.polluted);
```

Execute the following commands in terminal:

```
npm i jsonuri # Install affected module
node poc.js #  Run the PoC
```

Check the Output:

```
Before : undefined
After : Yes! Its Polluted
```

### 🔥 Proof of Fix (PoF) *

Before:

![image](https://user-images.githubusercontent.com/64132745/104120170-ba23c300-535a-11eb-9a94-7b1fa8a598fc.png)

After:

![image](https://user-images.githubusercontent.com/64132745/104120195-f6572380-535a-11eb-8ea8-4b93c0624b05.png)


### 👍 User Acceptance Testing (UAT)

![image](https://user-images.githubusercontent.com/64132745/104121055-8009ef80-5361-11eb-93e0-e29ae1eff06c.png)

After the fix, functionality is unaffected.

### 🔗 Relates to...

_Provide the URL of the PR for the disclosure that this fix relates to._
